### PR TITLE
From function pointer to function

### DIFF
--- a/callbackmanager.cpp
+++ b/callbackmanager.cpp
@@ -16,10 +16,11 @@
  export template <typename R, typename... Args>
   requires std::is_void<R>::value || std::is_arithmetic_v<R>
 class Callback {
+	using callbackfunction_t = std::function<R(Args...)>;	
 public:
 	Callback() : callback_(nullptr){}
 
-	inline void set(std::function<R(Args... args)> callback) {
+	inline void set(callbackfunction_t callback) {
 	    callback_ = & callback;
 	}
 
@@ -51,7 +52,7 @@ public:
 	}
 
 private:
-	std::function<R(Args... args)> *callback_;
+	callbackfunction_t *callback_;
 };
 
 } // namespace callbackmanager

--- a/callbackmanager.cpp
+++ b/callbackmanager.cpp
@@ -18,7 +18,7 @@
 class Callback {
 	using callbackfunction_t = std::function<R(Args...)>;	
 public:
-	Callback() : callback_(), isSet(false){}
+	Callback() : callback_(nullptr), isSet(false){}
 
 	inline void set(callbackfunction_t callback) {
 	    callback_ = callback;
@@ -26,6 +26,7 @@ public:
 	}
 
 	inline void unset() {
+		callback_ = nullptr;
 		isSet = false;
 	}
 

--- a/callbackmanager.cpp
+++ b/callbackmanager.cpp
@@ -18,15 +18,14 @@
 class Callback {
 	using callbackfunction_t = std::function<R(Args...)>;	
 public:
-	Callback() : callback_(nullptr), isSet(false){}
+	Callback() : callback_(), isSet(false){}
 
 	inline void set(callbackfunction_t callback) {
-	    callback_ = & callback;
+	    callback_ = callback;
 		isSet = true;
 	}
 
 	inline void unset() {
-	    callback_ = nullptr;
 		isSet = false;
 	}
 
@@ -38,14 +37,14 @@ public:
 			if (!isSet) {
 				return;
 			}
-			(*callback_)(args...);
+			(callback_)(args...);
 		}
 
 		if constexpr (! std::is_void<R>::value) {
 			if (!isSet) {
 				return 0; // R can only be a arithmetic type. 0 should work as default.
 			}
-			return (*callback_)(args...);
+			return (callback_)(args...);
 		}
 	}
 
@@ -54,7 +53,7 @@ public:
 	}
 
 private:
-	callbackfunction_t *callback_;
+	callbackfunction_t callback_;
 	bool isSet;
 };
 

--- a/callbackmanager.cpp
+++ b/callbackmanager.cpp
@@ -18,14 +18,16 @@
 class Callback {
 	using callbackfunction_t = std::function<R(Args...)>;	
 public:
-	Callback() : callback_(nullptr){}
+	Callback() : callback_(nullptr), isSet(false){}
 
 	inline void set(callbackfunction_t callback) {
 	    callback_ = & callback;
+		isSet = true;
 	}
 
 	inline void unset() {
 	    callback_ = nullptr;
+		isSet = false;
 	}
 
 	/*
@@ -33,14 +35,14 @@ public:
 	 */
 	inline R call(Args... args) {
 		if constexpr (std::is_void<R>::value) {
-			if (callback_ == nullptr) {
+			if (!isSet) {
 				return;
 			}
 			(*callback_)(args...);
 		}
 
 		if constexpr (! std::is_void<R>::value) {
-			if (callback_ == nullptr) {
+			if (!isSet) {
 				return 0; // R can only be a arithmetic type. 0 should work as default.
 			}
 			return (*callback_)(args...);
@@ -48,11 +50,12 @@ public:
 	}
 
 	inline bool is_set() {
-		return (callback_ != nullptr);		
+		return isSet;		
 	}
 
 private:
 	callbackfunction_t *callback_;
+	bool isSet;
 };
 
 } // namespace callbackmanager

--- a/example/callback_examples.cpp
+++ b/example/callback_examples.cpp
@@ -21,7 +21,6 @@ int functionHandler(const int& num1, const int& num2) {
     return num1 + num2;
 }
  
-__attribute__((optimize(0))) 
 int main() {
 
     int a = 4;

--- a/test/callbackmanager_test.cpp
+++ b/test/callbackmanager_test.cpp
@@ -2,8 +2,6 @@
 
 import callbackmanager;
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: call object method
 TEST(callback, objectMethod) {
     class MyClass {
@@ -23,10 +21,7 @@ TEST(callback, objectMethod) {
     ASSERT_EQ(cb.call(4, 5), 9);
     ASSERT_NE(cb.call(4, 5), 8);
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: call static method
 TEST(callback, classStaticMethod) {
     class MyClass {
@@ -44,10 +39,7 @@ TEST(callback, classStaticMethod) {
     ASSERT_EQ(cb.call(4, 5), 9);
     ASSERT_NE(cb.call(4, 5), 8);
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: call C function
 int functionHandler(const int& num1, const int& num2) {
     return num1 + num2;
@@ -62,10 +54,7 @@ TEST(callback, cFunction) {
     ASSERT_EQ(cb.call(4, 5), 9);
     ASSERT_NE(cb.call(4, 5), 8);
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: call pure lambda
 TEST(callback, lambda) {
 	callbackmanager::Callback<int, const int&, const int&> cb;
@@ -76,10 +65,7 @@ TEST(callback, lambda) {
     ASSERT_EQ(cb.call(4, 5), 9);
     ASSERT_NE(cb.call(4, 5), 8);
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: return a bool
 TEST(callback, bool) {
 	callbackmanager::Callback<bool, const int&, const int&> cb;
@@ -90,10 +76,7 @@ TEST(callback, bool) {
 	ASSERT_TRUE(cb.call(1, 1));
 	ASSERT_FALSE(cb.call(1, 2));
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: use void, and no attributes
 TEST(callback, voidWithoutParameters) {
 	callbackmanager::Callback<void> cb;
@@ -106,10 +89,7 @@ TEST(callback, voidWithoutParameters) {
     cb.call();
     ASSERT_TRUE(called);
 }
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: use void, and a const std::string reference
 TEST(callback, voidWithConstParameter) {
     callbackmanager::Callback<void, const std::string&> cb;
@@ -120,10 +100,7 @@ TEST(callback, voidWithConstParameter) {
     });
     cb.call("test");
 }    
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: no handler
 TEST(callback, noHandler) {
 	callbackmanager::Callback<void> cb;
@@ -131,10 +108,7 @@ TEST(callback, noHandler) {
     cb.call();
     ASSERT_TRUE(true); // call without callback should succeed
 }    
-#pragma GCC pop_options
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")  
 // scenario: set and unset
 TEST(callback, setUnset) {
 	callbackmanager::Callback<void> cb;
@@ -147,4 +121,3 @@ TEST(callback, setUnset) {
     cb.unset();
     ASSERT_FALSE(cb.is_set());
 }
-#pragma GCC pop_options


### PR DESCRIPTION
std::function is now a member instead of a function pointer.
Avoids that it holds a valid pointer to a std::function but implementation invalid.